### PR TITLE
update react version range

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "prepublish": "npm run build"
   },
   "peerDependencies": {
-    "react": "^16.8.0"
+    "react": "^16.8.0 || ^17.0.0"
   },
   "sideEffects": [
     "**/medium.js"


### PR DESCRIPTION
The library does seem to work fine in React 17 (as long as I could test in our app).

Changing the version declaration is required to for compatibility with npm v7 behavior

Sadly, it does not print the warnings for all packages, so I needed to wait for https://github.com/theKashey/react-clientside-effect/pull/3 to be released, to then find a few more missing declarations.

Let's see if the current batch (this PR and https://github.com/theKashey/use-callback-ref/pull/12) will be enough to make it work